### PR TITLE
Allow creating Dependabot Runners

### DIFF
--- a/app/clients/gcloud_client.py
+++ b/app/clients/gcloud_client.py
@@ -74,7 +74,12 @@ class GCloudClient:
                            "Skipping instance creation.")
             return None
 
-        instance_name = f"runner-{uuid.uuid4().hex[:16]}"
+        instance_uuid = uuid.uuid4().hex[:16]
+        if instance_template_resource.name.startswith("dependabot"):
+            instance_name = f"dependabot-{instance_uuid}"
+        else:
+            instance_name = f"runner-{instance_uuid}"
+
         logger.info(f"Creating GCE instance {instance_name} with template {instance_template_resource.self_link}")
 
         # Set instance name

--- a/app/services/webhook_service.py
+++ b/app/services/webhook_service.py
@@ -62,7 +62,7 @@ class WebhookService:
             template_name = None
             if labels:
                 for label in labels:
-                    if label.startswith('gcp-'):
+                    if label.startswith('gcp-') or label.lower() == 'dependabot':
                         template_name = label
                         break
             if template_name:

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -203,6 +203,18 @@ variable "github_runners_types" {
   # Similar to https://docs.github.com/en/enterprise-cloud@latest/actions/reference/runners/larger-runners
   default = [
     {
+      name                        = "dependabot"
+      instance_type               = "e2-medium"
+      vcpu                        = 2
+      memory                      = 4
+      disk_type                   = "pd-ssd"
+      disk_size                   = 50
+      disk_provisioned_iops       = 0
+      disk_provisioned_throughput = 0
+      image                       = "ubuntu-2404-lts-amd64"
+      arch                        = "amd64"
+    },
+    {
       name                        = "gcp-ubuntu-slim"
       instance_type               = "e2-medium"
       vcpu                        = 2
@@ -467,9 +479,9 @@ variable "github_runners_types" {
   validation {
     condition = alltrue([
       for config in var.github_runners_types :
-      can(regex("^gcp-[a-zA-Z0-9-]+$", config.name))
+      can(regex("(^dependabot$|^gcp-[a-zA-Z0-9-]+$)", config.name))
     ])
-    error_message = "All names must start with 'gcp-' and only contain letters, numbers and hyphens."
+    error_message = "All names must start with 'gcp-' or must be named 'dependabot' and only contain letters, numbers and hyphens."
   }
 
   validation {


### PR DESCRIPTION
First off, thanks for taking the time to contribute!

## Please Complete the Following

- [x] I read [CONTRIBUTING.md](https://github.com/Cyclenerd/google-cloud-github-runner/blob/master/CONTRIBUTING.md)

## Notes

We're running this in our Private Implementation of this project to have Private Services like Artifactory, Nexus Repository or other "on premises services" (what ever that means in that context) available to GitHub Actions runners.

The Runner Label must equal "dependabot" according to [the docs](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/manage-your-dependency-security/configure-on-self-hosted-runners).