### PR TITLE
Allow specification of Subnet CIDR for Runners

### DIFF
--- a/gcp/net-vpc.tf
+++ b/gcp/net-vpc.tf
@@ -7,7 +7,7 @@ module "vpc-github-runners" {
   description = "VPC for GitHub Actions Runners (Terraform-managed)"
   subnets = [
     {
-      ip_cidr_range = coalesce(var.github_runners_internal_cidr, "100.64.0.0/16") # https://en.wikipedia.org/wiki/Carrier-grade_NAT
+      ip_cidr_range = var.github_runners_internal_cidr
       name          = "subnet-github-runners-${local.region_shortnames[var.region]}"
       region        = var.region
       description   = "Subnet for GitHub Actions Runners in ${var.region} (Terraform-managed)"

--- a/gcp/net-vpc.tf
+++ b/gcp/net-vpc.tf
@@ -7,7 +7,7 @@ module "vpc-github-runners" {
   description = "VPC for GitHub Actions Runners (Terraform-managed)"
   subnets = [
     {
-      ip_cidr_range = "100.64.0.0/16" # https://en.wikipedia.org/wiki/Carrier-grade_NAT
+      ip_cidr_range = coalesce(var.github_runners_internal_cidr, "100.64.0.0/16") # https://en.wikipedia.org/wiki/Carrier-grade_NAT
       name          = "subnet-github-runners-${local.region_shortnames[var.region]}"
       region        = var.region
       description   = "Subnet for GitHub Actions Runners in ${var.region} (Terraform-managed)"

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -63,8 +63,13 @@ variable "zone" {
 variable "github_runners_internal_cidr" {
   description = "The Internal IP Range used for the GitHub Actions Runners"
   type        = string
-  default     = null
-  nullable    = true
+  default     = "100.64.0.0/16"
+  nullable    = false
+
+  validation {
+    condition     = can(cidrnetmask(var.github_runners_internal_cidr)) && can(regex("^([0-9]{1,3}\\.){3}[0-9]{1,3}/[0-9]{1,2}$", var.github_runners_internal_cidr))
+    error_message = "The value must be a valid IPv4 CIDR range."
+  }
 }
 
 # Minimum number of Cloud Run instances for the GitHub Actions Runners manager application

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -60,6 +60,13 @@ variable "zone" {
   }
 }
 
+variable "github_runners_internal_cidr" {
+  description = "The Internal IP Range used for the GitHub Actions Runners"
+  type        = string
+  default     = null
+  nullable    = true
+}
+
 # Minimum number of Cloud Run instances for the GitHub Actions Runners manager application
 # Unfortunately, the Cloud Run cold start time is slow and often exceeds 30 seconds.
 # GitHub expects a response to webhook requests in under 10 seconds!


### PR DESCRIPTION
First off, thanks for taking the time to contribute!

## Please Complete the Following

- [x] I read [CONTRIBUTING.md](https://github.com/Cyclenerd/google-cloud-github-runner/blob/master/CONTRIBUTING.md)

## Notes

Add Input Variable to allow the Subnet CIDR to be specified.
