### PR TITLE
Allow to specify `pd-balanced` as a disk type

### DIFF
--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -163,9 +163,9 @@ variable "github_runners_default_type" {
   validation {
     condition = alltrue([
       for value in values(var.github_runners_default_type) :
-      contains(["pd-ssd", "hyperdisk-balanced"], value.disk_type)
+      contains(["pd-ssd", "pd-balanced", "hyperdisk-balanced"], value.disk_type)
     ])
-    error_message = "Disk type must be either 'pd-ssd' or 'hyperdisk-balanced'."
+    error_message = "Disk type must be either 'pd-ssd', 'pd-balanced' or 'hyperdisk-balanced'."
   }
 
   validation {
@@ -492,9 +492,9 @@ variable "github_runners_types" {
   validation {
     condition = alltrue([
       for config in var.github_runners_types :
-      contains(["pd-ssd", "hyperdisk-balanced"], config.disk_type)
+      contains(["pd-ssd", "pd-balanced", "hyperdisk-balanced"], config.disk_type)
     ])
-    error_message = "Disk type must be either 'pd-ssd' or 'hyperdisk-balanced'."
+    error_message = "Disk type must be either 'pd-ssd', 'pd-balanced' or 'hyperdisk-balanced'."
   }
 
   validation {


### PR DESCRIPTION
First off, thanks for taking the time to contribute!

## Please Complete the Following

- [x] I read [CONTRIBUTING.md](https://github.com/Cyclenerd/google-cloud-github-runner/blob/master/CONTRIBUTING.md)

## Notes

While `pd-ssd` is matching the GitHub Hosted runners more closely we usually use `pd-balanced` to operate Compute Engine VMs a little more cost efficient. We haven't observed major performance penalties with pd-balanced, it'd be nice to get this as an option.