### PR TITLE
Terminate Compute Engine Instance after 5 days

### DIFF
--- a/gcp/compute-vm.tf
+++ b/gcp/compute-vm.tf
@@ -35,7 +35,8 @@ module "github-runners-vm-templates" {
 
   options = {
     termination_action = "DELETE"
-    max_run_duration   = {
+    # https://docs.github.com/en/actions/reference/limits#existing-system-limits
+    max_run_duration = {
       seconds = (86400 * 5) + 300 # Terminate Instance after 5 days, 5 minutes
     }
   }

--- a/gcp/compute-vm.tf
+++ b/gcp/compute-vm.tf
@@ -33,9 +33,9 @@ module "github-runners-vm-templates" {
     }
   }
 
-  scheduling {
+  options = {
     instance_termination_action = "DELETE"
-    max_run_duration {
+    max_run_duration = {
       # https://docs.github.com/en/actions/reference/limits#existing-system-limits
       seconds = (86400 * 5) + 300 # Terminate Instance after 5 days, 5 minutes
     }

--- a/gcp/compute-vm.tf
+++ b/gcp/compute-vm.tf
@@ -33,6 +33,14 @@ module "github-runners-vm-templates" {
     }
   }
 
+  scheduling {
+    instance_termination_action = "DELETE"
+    max_run_duration {
+      # https://docs.github.com/en/actions/reference/limits#existing-system-limits
+      seconds = (86400 * 5) + 300 # Terminate Instance after 5 days, 5 minutes
+    }
+  }
+
   service_account = {
     auto_create = false
     email       = module.service-account-compute-vm-github-runners.email

--- a/gcp/compute-vm.tf
+++ b/gcp/compute-vm.tf
@@ -34,9 +34,8 @@ module "github-runners-vm-templates" {
   }
 
   options = {
-    instance_termination_action = "DELETE"
-    max_run_duration = {
-      # https://docs.github.com/en/actions/reference/limits#existing-system-limits
+    termination_action = "DELETE"
+    max_run_duration   = {
       seconds = (86400 * 5) + 300 # Terminate Instance after 5 days, 5 minutes
     }
   }


### PR DESCRIPTION
First off, thanks for taking the time to contribute!

## Please Complete the Following

- [x] I read [CONTRIBUTING.md](https://github.com/Cyclenerd/google-cloud-github-runner/blob/master/CONTRIBUTING.md)

## Notes

Terminate Compute Engine Instances after 5 days (plus 5 minutes buffer). As [per Documentation](https://docs.github.com/en/actions/reference/limits#existing-system-limits) 5 days is the max. runtime for self hosted runners and we've never seen any stray instances with this project but having a safeguard in place feels reasonable.

