### PR TITLE
Add flags

### DIFF
--- a/app/clients/gcloud_client.py
+++ b/app/clients/gcloud_client.py
@@ -18,6 +18,7 @@ class GCloudClient:
         """Initialize GCloudClient with project and zone configuration."""
         self.project_id = os.environ.get('GOOGLE_CLOUD_PROJECT')
         self.zone = os.environ.get('GOOGLE_CLOUD_ZONE', 'us-central1-a')
+        self.github_runner_group = os.environ.get('GITHUB_RUNNER_GROUP', '').strip()
         self.region = '-'.join(self.zone.split('-')[:-1])
 
         if not self.project_id:
@@ -79,7 +80,7 @@ class GCloudClient:
         if instance_template_resource.name.startswith("dependabot"):
             instance_name = f"dependabot-{instance_uuid}"
         else:
-            instance_name = f"runner-{instance_uuid}"
+            instance_name = f"gcp-runner-{instance_uuid}"
 
         logger.info(f"Creating GCE instance {instance_name} with template {instance_template_resource.self_link}")
 
@@ -96,11 +97,20 @@ class GCloudClient:
             }
 
         # Set metadata (startup script) - use shlex.quote to prevent command injection
+        runner_group_flag = ""
+        if self.github_runner_group:
+            runner_group_flag = f" --runnergroup {shlex.quote(self.github_runner_group)}"
+
         startup_script = (
             f"sudo -u runner /actions-runner/config.sh --url {shlex.quote(repo_url)} "
             f"--token {shlex.quote(registration_token)} "
-            f"--name {shlex.quote(instance_name)} --labels {shlex.quote(template_name)} "
-            "--ephemeral --unattended --no-default-labels --disableupdate && "
+            f"--name {shlex.quote(instance_name)} "
+            f"--labels {shlex.quote(template_name)} "
+            f"{runner_group_flag} "
+            "--ephemeral "
+            "--unattended "
+            "--no-default-labels "
+            "--disableupdate && "
             "sudo -u runner /actions-runner/run.sh"
         )
         metadata = compute_v1.Metadata()

--- a/app/clients/gcloud_client.py
+++ b/app/clients/gcloud_client.py
@@ -102,7 +102,8 @@ class GCloudClient:
             runner_group_flag = f" --runnergroup {shlex.quote(self.github_runner_group)}"
 
         startup_script = (
-            f"sudo -u runner /actions-runner/config.sh --url {shlex.quote(repo_url)} "
+            "cd /actions-runner && "
+            f"sudo -u runner ./config.sh --url {shlex.quote(repo_url)} "
             f"--token {shlex.quote(registration_token)} "
             f"--name {shlex.quote(instance_name)} "
             f"--labels {shlex.quote(template_name)} "
@@ -111,7 +112,7 @@ class GCloudClient:
             "--unattended "
             "--no-default-labels "
             "--disableupdate && "
-            "sudo -u runner /actions-runner/run.sh"
+            "sudo -u runner ./run.sh"
         )
         metadata = compute_v1.Metadata()
         metadata.items = [

--- a/app/clients/gcloud_client.py
+++ b/app/clients/gcloud_client.py
@@ -76,7 +76,8 @@ class GCloudClient:
                            "Skipping instance creation.")
             return None
 
-        # Name must start with a lowercase letter followed by up to 62 lowercase letters, numbers, or hyphens, and cannot end with a hyphen
+        # Name must start with a lowercase letter followed by up to 62 lowercase letters,
+        # numbers, or hyphens, and cannot end with a hyphen.
         instance_uuid = uuid.uuid4().hex[:16]
         if instance_template_resource.name.startswith("dependabot"):
             instance_name = f"gcp-runner-dependabot-{instance_uuid}"

--- a/app/clients/gcloud_client.py
+++ b/app/clients/gcloud_client.py
@@ -76,9 +76,10 @@ class GCloudClient:
                            "Skipping instance creation.")
             return None
 
+        # Name must start with a lowercase letter followed by up to 62 lowercase letters, numbers, or hyphens, and cannot end with a hyphen
         instance_uuid = uuid.uuid4().hex[:16]
         if instance_template_resource.name.startswith("dependabot"):
-            instance_name = f"dependabot-{instance_uuid}"
+            instance_name = f"gcp-runner-dependabot-{instance_uuid}"
         else:
             instance_name = f"gcp-runner-{instance_uuid}"
 

--- a/app/services/webhook_service.py
+++ b/app/services/webhook_service.py
@@ -104,6 +104,10 @@ class WebhookService:
             logger.warning("Job completed but no runner_name found in payload.")
             return
 
+        if not runner_name.startswith('gcp-runner-'):
+            logger.warning("gcp-runner prefix not found in runner name %s. Ignoring job.", runner_name)
+            return
+
         try:
             self.gcloud_client.delete_runner_instance(runner_name)
         except Exception as e:

--- a/gcp/cloud-run.tf
+++ b/gcp/cloud-run.tf
@@ -31,6 +31,7 @@ module "cloud_run_github_runners_manager" {
       env = {
         GOOGLE_CLOUD_PROJECT = var.project_id
         GOOGLE_CLOUD_ZONE    = "${var.region}-${var.zone}"
+        GITHUB_RUNNER_GROUP  = var.github_runner_group
       }
       env_from_key = {
         GITHUB_APP_ID = {

--- a/gcp/compute-vm.tf
+++ b/gcp/compute-vm.tf
@@ -37,7 +37,7 @@ module "github-runners-vm-templates" {
     termination_action = "DELETE"
     # https://docs.github.com/en/actions/reference/limits#existing-system-limits
     max_run_duration = {
-      seconds = (86400 * 5) + 300 # Terminate Instance after 5 days, 5 minutes
+      seconds = var.github_runners_max_run_duration
     }
   }
 

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -60,6 +60,13 @@ variable "zone" {
   }
 }
 
+variable "github_runner_group" {
+  description = "GitHub Actions runner group name passed to the Cloud Run service; blank disables --runnergroup"
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
 variable "github_runners_internal_cidr" {
   description = "The Internal IP Range used for the GitHub Actions Runners"
   type        = string

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -107,6 +107,18 @@ variable "github_runners_manager_max_instance_count" {
   }
 }
 
+# Maximum runtime for GitHub Actions runner VMs before Compute Engine force-deletes them
+variable "github_runners_max_run_duration" {
+  description = "Maximum runtime in seconds for GitHub Actions runner VMs before termination"
+  type        = number
+  default     = (86400 * 5) + 300
+
+  validation {
+    condition     = var.github_runners_max_run_duration > 0
+    error_message = "Maximum run duration must be greater than 0 seconds."
+  }
+}
+
 # Map of default VM images for GitHub Actions Runners by architecture
 variable "github_runners_default_image" {
   description = "Default GitHub Actions Runners images (family images) for different CPU architectures"

--- a/tests/unit/test_gcloud_client.py
+++ b/tests/unit/test_gcloud_client.py
@@ -32,6 +32,7 @@ class TestGCloudClient:
 
         assert client.project_id == 'test-project'
         assert client.zone == 'us-central1-a'
+        assert client.github_runner_group == ''
         assert client.region == 'us-central1'
 
     def test_init_default_zone(self, monkeypatch, mock_compute_clients, mock_gcloud_auth):
@@ -43,6 +44,16 @@ class TestGCloudClient:
 
         assert client.zone == 'us-central1-a'
         assert client.region == 'us-central1'
+
+    def test_init_with_runner_group(self, monkeypatch, mock_compute_clients, mock_gcloud_auth):
+        """Test GCloudClient initialization with runner group."""
+        monkeypatch.setenv('GOOGLE_CLOUD_PROJECT', 'test-project')
+        monkeypatch.setenv('GOOGLE_CLOUD_ZONE', 'us-central1-a')
+        monkeypatch.setenv('GITHUB_RUNNER_GROUP', 'platform-runners')
+
+        client = GCloudClient()
+
+        assert client.github_runner_group == 'platform-runners'
 
     def test_init_missing_project_id(self, mock_compute_clients, mock_gcloud_auth):
         """Test GCloudClient initialization with missing project ID."""
@@ -77,6 +88,40 @@ class TestGCloudClient:
 
         assert instance_name.startswith('runner-')
         mock_instance_client.insert.assert_called_once()
+
+        request = mock_instance_client.insert.call_args.kwargs['request']
+        startup_script = request.instance_resource.metadata.items[0].value
+        assert '--runnergroup' not in startup_script
+
+    @patch('app.clients.gcloud_client.compute_v1')
+    def test_create_runner_instance_with_runner_group(self, mock_compute, monkeypatch, mock_env_vars):
+        """Test creating a runner instance with runner group."""
+        monkeypatch.setenv('GITHUB_RUNNER_GROUP', 'platform-runners')
+
+        mock_instance_client = MagicMock()
+        mock_operation = MagicMock()
+        mock_operation.name = 'operation-123'
+        mock_instance_client.insert.return_value = mock_operation
+        mock_compute.InstancesClient.return_value = mock_instance_client
+
+        mock_templates_client = MagicMock()
+        mock_template = MagicMock()
+        mock_template.name = 'gcp-ubuntu-24-04-12345678901234'
+        mock_template.self_link = ('https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/'
+                                   'instanceTemplates/gcp-ubuntu-24-04-12345678901234')
+        mock_templates_client.list.return_value = [mock_template]
+        mock_compute.RegionInstanceTemplatesClient.return_value = mock_templates_client
+
+        client = GCloudClient()
+        client.create_runner_instance(
+            'fake-token-12345678',
+            'https://github.com/owner/repo',
+            'gcp-ubuntu-24.04'
+        )
+
+        request = mock_instance_client.insert.call_args.kwargs['request']
+        startup_script = request.instance_resource.metadata.items[0].value
+        assert '--runnergroup platform-runners' in startup_script
 
     @patch('app.clients.gcloud_client.compute_v1')
     def test_create_runner_instance_error(self, mock_compute, mock_env_vars):

--- a/tests/unit/test_gcloud_client.py
+++ b/tests/unit/test_gcloud_client.py
@@ -86,11 +86,13 @@ class TestGCloudClient:
             'gcp-ubuntu-24.04'
         )
 
-        assert instance_name.startswith('runner-')
+        assert instance_name.startswith('gcp-runner-')
         mock_instance_client.insert.assert_called_once()
 
-        request = mock_instance_client.insert.call_args.kwargs['request']
-        startup_script = request.instance_resource.metadata.items[0].value
+        startup_script = mock_compute.Items.call_args_list[0].kwargs['value']
+        assert startup_script.startswith('cd /actions-runner && ')
+        assert 'sudo -u runner ./config.sh' in startup_script
+        assert 'sudo -u runner ./run.sh' in startup_script
         assert '--runnergroup' not in startup_script
 
     @patch('app.clients.gcloud_client.compute_v1')
@@ -119,8 +121,8 @@ class TestGCloudClient:
             'gcp-ubuntu-24.04'
         )
 
-        request = mock_instance_client.insert.call_args.kwargs['request']
-        startup_script = request.instance_resource.metadata.items[0].value
+        startup_script = mock_compute.Items.call_args_list[0].kwargs['value']
+        assert startup_script.startswith('cd /actions-runner && ')
         assert '--runnergroup platform-runners' in startup_script
 
     @patch('app.clients.gcloud_client.compute_v1')

--- a/tests/unit/test_webhook_service.py
+++ b/tests/unit/test_webhook_service.py
@@ -112,13 +112,13 @@ class TestWebhookService:
         payload = {
             'action': 'completed',
             'workflow_job': {
-                'runner_name': 'runner-12345'
+                'runner_name': 'gcp-runner-12345'
             }
         }
 
         service.handle_workflow_job(payload)
 
-        mock_gc_client.delete_runner_instance.assert_called_once_with('runner-12345')
+        mock_gc_client.delete_runner_instance.assert_called_once_with('gcp-runner-12345')
 
     @patch('app.services.webhook_service.GCloudClient')
     @patch('app.services.webhook_service.GitHubClient')
@@ -208,11 +208,11 @@ class TestWebhookService:
         payload = {
             'action': 'completed',
             'workflow_job': {
-                'runner_name': 'runner-12345'
+                'runner_name': 'gcp-runner-12345'
             }
         }
 
         # Should not raise exception, just log error
         service.handle_workflow_job(payload)
 
-        mock_gc_client.delete_runner_instance.assert_called_once_with('runner-12345')
+        mock_gc_client.delete_runner_instance.assert_called_once_with('gcp-runner-12345')


### PR DESCRIPTION
### Changes and Fixes

- Added support to pass `--runnergroup` flag to `config.sh` when installing the runner software. The flag is configured using a terraform variable `github_runner_group` and the default values is "".

- Added support to configure the runner VM `max_run_duration` using a terraform variable `github_runners_max_run_duration`. The value is specified in seconds. The default is `(86400 * 5) + 300` 

- Renamed the runners from `runner-{instance_uuid}` to `gcp-runner-{instance_uuid}`. This allows runners to be more easily identified in github for maintenance. Also, and perhaps more importantly, `_handle_completed_job`will now be able to identify and shut down VMs for gcp runners and not unrelated runners.

- `webhook_service.py` `_handle_completed_job`: Only shutdown VMs from runners whose name starts with `gcp-runner-`

- The VM startup_script will now `cd` into the `runner-actions` folder before executing `run.sh`. This solves ` ldd: ./bin/libcoreclr.so: No such file or directory` and two other `No such file or directory` errors. Changing directories into the `runner-actions` folder is the formal procedure when installing the runner software.
