### PR TITLE
Provide additional Details for Webhook Operations

### DIFF
--- a/app/clients/gcloud_client.py
+++ b/app/clients/gcloud_client.py
@@ -54,7 +54,14 @@ class GCloudClient:
         except Exception:
             return None
 
-    def create_runner_instance(self, registration_token, repo_url, template_name, instance_label=None):
+    def create_runner_instance(
+        self,
+        registration_token,
+        repo_url,
+        template_name,
+        instance_label=None,
+        delivery_id=None,
+    ):
         """
         Create a new GCE instance for a GitHub Actions runner.
 
@@ -63,16 +70,26 @@ class GCloudClient:
             repo_url (str): The URL of the repository or organization.
             template_name (str): The name of the instance template to use.
             instance_label (str): Label to add to the Instance for Cost Tracking.
+            delivery_id (str): The GitHub webhook delivery ID for log correlation.
 
         Returns:
             str: The name of the created instance.
         """
         instance_template_resource = self._get_template_name(template_name)
         if instance_template_resource:
-            logger.info(f"Found matching instance template: {instance_template_resource.name}")
+            logger.info(
+                "Found matching instance template: %s, delivery_id: %s",
+                instance_template_resource.name,
+                delivery_id,
+            )
         else:
-            logger.warning(f"No matching instance template found for label '{template_name}' in region {self.region}. "
-                           "Skipping instance creation.")
+            logger.warning(
+                "No matching instance template found for label '%s' in region %s. "
+                "Skipping instance creation. delivery_id: %s",
+                template_name,
+                self.region,
+                delivery_id,
+            )
             return None
 
         instance_uuid = uuid.uuid4().hex[:16]
@@ -81,7 +98,12 @@ class GCloudClient:
         else:
             instance_name = f"runner-{instance_uuid}"
 
-        logger.info(f"Creating GCE instance {instance_name} with template {instance_template_resource.self_link}")
+        logger.info(
+            "Creating GCE instance %s with template %s, delivery_id: %s",
+            instance_name,
+            instance_template_resource.self_link,
+            delivery_id,
+        )
 
         # Set instance name
         instance_resource = compute_v1.Instance()  # google.cloud.compute_v1.types.Instance
@@ -122,30 +144,46 @@ class GCloudClient:
 
         try:
             # https://docs.cloud.google.com/compute/docs/reference/rest/v1/instances/insert
-            operation = self.instance_client.insert(
-                request=request
+            operation = self.instance_client.insert(request=request)
+            logger.info(
+                "Instance creation operation started: %s, delivery_id: %s",
+                operation.name,
+                delivery_id,
             )
-            logger.info(f"Instance creation operation started: {operation.name}")
             return instance_name
         except Exception as e:
-            logger.error(f"Failed to create instance: {e}")
+            logger.error(
+                "Failed to create instance: %s, delivery_id: %s", e, delivery_id
+            )
             raise
 
-    def delete_runner_instance(self, instance_name):
+    def delete_runner_instance(self, instance_name, delivery_id=None):
         """
         Delete a GCE instance.
 
         Args:
             instance_name (str): The name of the instance to delete.
+            delivery_id (str): The GitHub webhook delivery ID for log correlation.
         """
-        logger.info(f"Deleting GCE instance {instance_name}")
+        logger.info(
+            "Deleting GCE instance %s, delivery_id: %s", instance_name, delivery_id
+        )
         try:
             operation = self.instance_client.delete(
                 project=self.project_id,
                 zone=self.zone,
                 instance=instance_name
             )
-            logger.info(f"Instance deletion operation started: {operation.name}")
+            logger.info(
+                "Instance deletion operation started: %s, delivery_id: %s",
+                operation.name,
+                delivery_id,
+            )
         except Exception as e:
-            logger.error(f"Failed to delete instance {instance_name}: {e}")
+            logger.error(
+                "Failed to delete instance %s: %s, delivery_id: %s",
+                instance_name,
+                e,
+                delivery_id,
+            )
             raise

--- a/app/clients/github_client.py
+++ b/app/clients/github_client.py
@@ -79,7 +79,7 @@ class GitHubClient:
         # The installation access token will expire after 1 hour.
         return response.json()['token']
 
-    def get_registration_token(self, org_name=None, repo_name=None):
+    def get_registration_token(self, org_name=None, repo_name=None, delivery_id=None):
         """Gets a runner registration token."""
         # https://docs.github.com/en/rest/actions/self-hosted-runners
         token = self.get_installation_access_token()
@@ -90,12 +90,20 @@ class GitHubClient:
         }
         if org_name:
             # GitHub Docs: https://t.ly/dAyGK
-            url = f'https://api.github.com/orgs/{org_name}/actions/runners/registration-token'
-            logger.info(f"Create registration token for organization: {org_name}")
+            url = f"https://api.github.com/orgs/{org_name}/actions/runners/registration-token"
+            logger.info(
+                "Create registration token for organization: %s, delivery_id: %s",
+                org_name,
+                delivery_id,
+            )
         elif repo_name:
             # GitHub Docs: https://t.ly/n0w2a
-            url = f'https://api.github.com/repos/{repo_name}/actions/runners/registration-token'
-            logger.info(f"Create registration token for repository: {repo_name}")
+            url = f"https://api.github.com/repos/{repo_name}/actions/runners/registration-token"
+            logger.info(
+                "Create registration token for repository: %s, delivery_id: %s",
+                repo_name,
+                delivery_id,
+            )
         else:
             raise ValueError("Either org_name or repo_name must be provided")
 

--- a/app/routes/webhook.py
+++ b/app/routes/webhook.py
@@ -73,7 +73,7 @@ def handle_workflow_job_event(payload, delivery_id=None):
     """Handle workflow_job event."""
     try:
         webhook_service = WebhookService()
-        result = webhook_service.handle_workflow_job(payload)
+        result = webhook_service.handle_workflow_job(payload, delivery_id=delivery_id)
         logger.info(
             "Webhook processed successfully, action: %s, runner_name: %s, "
             "delivery_id: %s",

--- a/app/routes/webhook.py
+++ b/app/routes/webhook.py
@@ -59,8 +59,17 @@ def handle_workflow_job_event(payload):
     """Handle workflow_job event."""
     try:
         webhook_service = WebhookService()
-        webhook_service.handle_workflow_job(payload)
-        return jsonify({'status': 'success'}), 200
+        result = webhook_service.handle_workflow_job(payload)
+        return (
+            jsonify(
+                {
+                    'status': 'success',
+                    'action': result.get('action'),
+                    'runner_name': result.get('runner_name'),
+                }
+            ),
+            200,
+        )
     except ValueError as e:
         logger.error("[Webhook] Validation error: %s", str(e))
         return jsonify({'status': 'error', 'message': 'Invalid payload'}), 400

--- a/app/routes/webhook.py
+++ b/app/routes/webhook.py
@@ -18,13 +18,15 @@ def webhook():
     """Handle incoming GitHub webhook events."""
     # https://docs.github.com/en/webhooks/webhook-events-and-payloads
     event_type = request.headers.get('X-GitHub-Event')
+    # https://docs.github.com/en/webhooks/webhook-events-and-payloads#delivery-headers
+    delivery_id = request.headers.get('X-GitHub-Delivery')
 
     # Validate event type
     if not event_type or not isinstance(event_type, str):
         logger.error("Missing or invalid X-GitHub-Event header")
         return jsonify({'status': 'error', 'message': 'Invalid event type'}), 400
 
-    logger.info("Received webhook event: %s", event_type)
+    logger.info("Received webhook event: %s, delivery_id: %s", event_type, delivery_id)
 
     # Handle ping event
     if event_type == 'ping':
@@ -34,32 +36,51 @@ def webhook():
     signature = request.headers.get('X-Hub-Signature-256')
 
     if not verify_github_signature(request.data, signature):
-        logger.error("GitHub webhook signature not successfully verified! Ignoring webhook event.")
+        logger.error(
+            "GitHub webhook signature not successfully verified! "
+            "Ignoring webhook event. delivery_id: %s",
+            delivery_id,
+        )
         return jsonify({'status': 'forbidden', 'message': 'Invalid signature'}), 403
 
     # Validate JSON payload
     try:
         payload = request.json
         if not payload:
-            logger.error("Empty or invalid JSON payload")
+            logger.error("Empty or invalid JSON payload, delivery_id: %s", delivery_id)
             return jsonify({'status': 'error', 'message': 'Invalid JSON payload'}), 400
     except Exception as e:
-        logger.error("Failed to parse JSON payload: %s", str(e))
+        logger.error(
+            "Failed to parse JSON payload: %s, delivery_id: %s",
+            str(e),
+            delivery_id,
+        )
         return jsonify({'status': 'error', 'message': 'Invalid JSON'}), 400
 
     # https://docs.github.com/en/webhooks/webhook-events-and-payloads#workflow_job
     if event_type == 'workflow_job':
-        return handle_workflow_job_event(payload)
+        return handle_workflow_job_event(payload, delivery_id)
     else:
-        logger.warning("Received unknown event type: %s", event_type)
+        logger.warning(
+            "Received unknown event type: %s, delivery_id: %s",
+            event_type,
+            delivery_id,
+        )
         return jsonify({'status': 'ignored'}), 200
 
 
-def handle_workflow_job_event(payload):
+def handle_workflow_job_event(payload, delivery_id=None):
     """Handle workflow_job event."""
     try:
         webhook_service = WebhookService()
         result = webhook_service.handle_workflow_job(payload)
+        logger.info(
+            "Webhook processed successfully, action: %s, runner_name: %s, "
+            "delivery_id: %s",
+            result.get("action"),
+            result.get("runner_name"),
+            delivery_id,
+        )
         return (
             jsonify(
                 {
@@ -71,8 +92,16 @@ def handle_workflow_job_event(payload):
             200,
         )
     except ValueError as e:
-        logger.error("[Webhook] Validation error: %s", str(e))
+        logger.error(
+            "[Webhook] Validation error: %s, delivery_id: %s",
+            str(e),
+            delivery_id,
+        )
         return jsonify({'status': 'error', 'message': 'Invalid payload'}), 400
     except Exception as e:
-        logger.error("[Webhook] Error handling webhook: %s", str(e))
+        logger.error(
+            "[Webhook] Error handling webhook: %s, delivery_id: %s",
+            str(e),
+            delivery_id,
+        )
         return jsonify({'status': 'error', 'message': 'Internal error'}), 500

--- a/app/services/webhook_service.py
+++ b/app/services/webhook_service.py
@@ -40,7 +40,7 @@ class WebhookService:
 
         return True
 
-    def handle_workflow_job(self, payload):
+    def handle_workflow_job(self, payload, delivery_id=None):
         """Process the workflow_job webhook payload from GitHub.
 
         Returns:
@@ -59,7 +59,12 @@ class WebhookService:
         org_name = payload.get('organization', {}).get('login')
 
         # Sanitize log output - don't log full payload
-        logger.info("Processing workflow_job action: %s for %s", action, org_name or repo_name)
+        logger.info(
+            "Processing workflow_job action: %s for %s, delivery_id: %s",
+            action,
+            org_name or repo_name,
+            delivery_id,
+        )
 
         # https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=queued#workflow_job
         if action == 'queued':
@@ -70,27 +75,46 @@ class WebhookService:
                         template_name = label
                         break
             if template_name:
-                logger.info("Found matching label prefix: %s", template_name)
+                logger.info(
+                    "Found matching label prefix: %s, delivery_id: %s",
+                    template_name,
+                    delivery_id,
+                )
                 instance_name = self._handle_queued_job(
-                    template_name, repo_url, repo_owner_url, repo_name, org_name
+                    template_name,
+                    repo_url,
+                    repo_owner_url,
+                    repo_name,
+                    org_name,
+                    delivery_id=delivery_id,
                 )
                 return {'action': 'created', 'runner_name': instance_name}
             else:
                 logger.warning(
-                    "No matching gcp- label prefix found for labels %s. Ignoring job.",
+                    "No matching gcp- label prefix found for labels %s. "
+                    "Ignoring job. delivery_id: %s",
                     labels,
+                    delivery_id,
                 )
                 return {'action': 'ignored', 'runner_name': None}
 
         # https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=completed#workflow_job
         elif action == 'completed':
-            runner_name = self._handle_completed_job(workflow_job)
+            runner_name = self._handle_completed_job(
+                workflow_job, delivery_id=delivery_id
+            )
             return {'action': 'deleted', 'runner_name': runner_name}
 
         return {'action': 'ignored', 'runner_name': None}
 
     def _handle_queued_job(
-        self, template_name, repo_url, repo_owner_url, repo_name, org_name
+        self,
+        template_name,
+        repo_url,
+        repo_owner_url,
+        repo_name,
+        org_name,
+        delivery_id=None,
     ):
         """Handle queued workflow job.
 
@@ -101,42 +125,68 @@ class WebhookService:
             # Get registration token
             if org_name:
                 # Create GitHub Actions runner instance for organization
-                token = self.github_client.get_registration_token(org_name=org_name)
+                token = self.github_client.get_registration_token(
+                    org_name=org_name, delivery_id=delivery_id
+                )
                 return self.gcloud_client.create_runner_instance(
-                    token, repo_owner_url, template_name, repo_name
+                    token,
+                    repo_owner_url,
+                    template_name,
+                    repo_name,
+                    delivery_id=delivery_id,
                 )
             elif repo_name:
                 # Create GitHub Actions runner instance for repository
-                token = self.github_client.get_registration_token(repo_name=repo_name)
+                token = self.github_client.get_registration_token(
+                    repo_name=repo_name, delivery_id=delivery_id
+                )
                 return self.gcloud_client.create_runner_instance(
-                    token, repo_url, template_name, repo_name
+                    token, repo_url, template_name, repo_name, delivery_id=delivery_id
                 )
             else:
                 logger.error(
-                    "Neither repository nor organization found in payload. Ignoring job."
+                    "Neither repository nor organization found in payload. "
+                    "Ignoring job. delivery_id: %s",
+                    delivery_id,
                 )
                 return None
 
         except Exception as e:
-            logger.error("Failed to spawn runner: %s", str(e))
+            logger.error(
+                "Failed to spawn runner: %s, delivery_id: %s", str(e), delivery_id
+            )
             raise
 
-    def _handle_completed_job(self, workflow_job):
+    def _handle_completed_job(self, workflow_job, delivery_id=None):
         """Handle completed workflow job.
 
         Returns:
             str or None: The name of the deleted runner instance.
         """
         runner_name = workflow_job.get('runner_name')
-        logger.info("Job completed. Cleaning up runner: %s", runner_name)
+        logger.info(
+            "Job completed. Cleaning up runner: %s, delivery_id: %s",
+            runner_name,
+            delivery_id,
+        )
 
         if not runner_name:
-            logger.warning("Job completed but no runner_name found in payload.")
+            logger.warning(
+                "Job completed but no runner_name found in payload. delivery_id: %s",
+                delivery_id,
+            )
             return None
 
         try:
-            self.gcloud_client.delete_runner_instance(runner_name)
+            self.gcloud_client.delete_runner_instance(
+                runner_name, delivery_id=delivery_id
+            )
             return runner_name
         except Exception as e:
-            logger.error("Failed to delete runner %s: %s", runner_name, str(e))
+            logger.error(
+                "Failed to delete runner %s: %s, delivery_id: %s",
+                runner_name,
+                str(e),
+                delivery_id,
+            )
             return runner_name

--- a/app/services/webhook_service.py
+++ b/app/services/webhook_service.py
@@ -41,7 +41,11 @@ class WebhookService:
         return True
 
     def handle_workflow_job(self, payload):
-        """Process the workflow_job webhook payload from GitHub."""
+        """Process the workflow_job webhook payload from GitHub.
+
+        Returns:
+            dict: A result dict with 'action' and 'runner_name' keys.
+        """
         # Validate payload structure
         self._validate_payload(payload)
 
@@ -66,45 +70,73 @@ class WebhookService:
                         template_name = label
                         break
             if template_name:
-                logger.info("Found matching gcp- label prefix: %s", template_name)
-                self._handle_queued_job(template_name, repo_url, repo_owner_url, repo_name, org_name)
+                logger.info("Found matching label prefix: %s", template_name)
+                instance_name = self._handle_queued_job(
+                    template_name, repo_url, repo_owner_url, repo_name, org_name
+                )
+                return {'action': 'created', 'runner_name': instance_name}
             else:
-                logger.warning("No matching gcp- label prefix found for labels %s. Ignoring job.", labels)
+                logger.warning(
+                    "No matching gcp- label prefix found for labels %s. Ignoring job.",
+                    labels,
+                )
+                return {'action': 'ignored', 'runner_name': None}
 
         # https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=completed#workflow_job
         elif action == 'completed':
-            self._handle_completed_job(workflow_job)
+            runner_name = self._handle_completed_job(workflow_job)
+            return {'action': 'deleted', 'runner_name': runner_name}
 
-    def _handle_queued_job(self, template_name, repo_url, repo_owner_url, repo_name, org_name):
-        """Handle queued workflow job."""
+        return {'action': 'ignored', 'runner_name': None}
+
+    def _handle_queued_job(
+        self, template_name, repo_url, repo_owner_url, repo_name, org_name
+    ):
+        """Handle queued workflow job.
+
+        Returns:
+            str or None: The name of the created runner instance.
+        """
         try:
             # Get registration token
             if org_name:
                 # Create GitHub Actions runner instance for organization
                 token = self.github_client.get_registration_token(org_name=org_name)
-                self.gcloud_client.create_runner_instance(token, repo_owner_url, template_name, repo_name)
+                return self.gcloud_client.create_runner_instance(
+                    token, repo_owner_url, template_name, repo_name
+                )
             elif repo_name:
                 # Create GitHub Actions runner instance for repository
                 token = self.github_client.get_registration_token(repo_name=repo_name)
-                self.gcloud_client.create_runner_instance(token, repo_url, template_name, repo_name)
+                return self.gcloud_client.create_runner_instance(
+                    token, repo_url, template_name, repo_name
+                )
             else:
-                logger.error("Neither repository nor organization found in payload. Ignoring job.")
-                return
+                logger.error(
+                    "Neither repository nor organization found in payload. Ignoring job."
+                )
+                return None
 
         except Exception as e:
             logger.error("Failed to spawn runner: %s", str(e))
             raise
 
     def _handle_completed_job(self, workflow_job):
-        """Handle completed workflow job."""
+        """Handle completed workflow job.
+
+        Returns:
+            str or None: The name of the deleted runner instance.
+        """
         runner_name = workflow_job.get('runner_name')
         logger.info("Job completed. Cleaning up runner: %s", runner_name)
 
         if not runner_name:
             logger.warning("Job completed but no runner_name found in payload.")
-            return
+            return None
 
         try:
             self.gcloud_client.delete_runner_instance(runner_name)
+            return runner_name
         except Exception as e:
             logger.error("Failed to delete runner %s: %s", runner_name, str(e))
+            return runner_name

--- a/tests/unit/test_gcloud_client.py
+++ b/tests/unit/test_gcloud_client.py
@@ -1,4 +1,5 @@
 import pytest
+import logging
 from unittest.mock import patch, MagicMock
 from app.clients.gcloud_client import GCloudClient
 
@@ -196,3 +197,151 @@ class TestGCloudClient:
 
         assert result is None
         mock_instance_client.insert.assert_not_called()
+
+
+class TestGCloudClientDeliveryIdLogging:
+    """Tests to verify that delivery_id is logged in GCloudClient methods."""
+
+    @patch("app.clients.gcloud_client.compute_v1")
+    def test_create_runner_instance_logs_delivery_id(
+        self, mock_compute, mock_env_vars, caplog
+    ):
+        """Test that delivery_id is logged when creating an instance."""
+        mock_instance_client = MagicMock()
+        mock_operation = MagicMock()
+        mock_operation.name = "operation-123"
+        mock_instance_client.insert.return_value = mock_operation
+        mock_compute.InstancesClient.return_value = mock_instance_client
+
+        mock_templates_client = MagicMock()
+        mock_template = MagicMock()
+        mock_template.name = "gcp-ubuntu-24-04-12345678901234"
+        mock_template.self_link = (
+            "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/"
+            "instanceTemplates/gcp-ubuntu-24-04-12345678901234"
+        )
+        mock_templates_client.list.return_value = [mock_template]
+        mock_compute.RegionInstanceTemplatesClient.return_value = mock_templates_client
+
+        client = GCloudClient()
+
+        with caplog.at_level(logging.INFO, logger="app.clients.gcloud_client"):
+            client.create_runner_instance(
+                "fake-token",
+                "https://github.com/owner/repo",
+                "gcp-ubuntu-24.04",
+                delivery_id="gce-create-delivery-001",
+            )
+
+        delivery_logs = [
+            r for r in caplog.records if "gce-create-delivery-001" in r.message
+        ]
+        assert (
+            len(delivery_logs) >= 2
+        ), "Expected delivery_id in at least 2 log lines (template match + creating + operation)"
+
+    @patch("app.clients.gcloud_client.compute_v1")
+    def test_delete_runner_instance_logs_delivery_id(
+        self, mock_compute, mock_env_vars, caplog
+    ):
+        """Test that delivery_id is logged when deleting an instance."""
+        mock_instance_client = MagicMock()
+        mock_operation = MagicMock()
+        mock_operation.name = "delete-operation-123"
+        mock_instance_client.delete.return_value = mock_operation
+        mock_compute.InstancesClient.return_value = mock_instance_client
+
+        client = GCloudClient()
+
+        with caplog.at_level(logging.INFO, logger="app.clients.gcloud_client"):
+            client.delete_runner_instance(
+                "runner-12345", delivery_id="gce-delete-delivery-001"
+            )
+
+        delivery_logs = [
+            r for r in caplog.records if "gce-delete-delivery-001" in r.message
+        ]
+        assert (
+            len(delivery_logs) >= 2
+        ), "Expected delivery_id in at least 2 log lines (deleting + operation)"
+
+    @patch("app.clients.gcloud_client.compute_v1")
+    def test_create_runner_instance_no_template_logs_delivery_id(
+        self, mock_compute, mock_env_vars, caplog
+    ):
+        """Test that delivery_id is logged when no matching template found."""
+        mock_templates_client = MagicMock()
+        mock_templates_client.list.return_value = []
+        mock_compute.RegionInstanceTemplatesClient.return_value = mock_templates_client
+
+        mock_instance_client = MagicMock()
+        mock_compute.InstancesClient.return_value = mock_instance_client
+
+        client = GCloudClient()
+
+        with caplog.at_level(logging.WARNING, logger="app.clients.gcloud_client"):
+            client.create_runner_instance(
+                "fake-token",
+                "https://github.com/owner/repo",
+                "non-existent",
+                delivery_id="gce-notemplate-delivery-001",
+            )
+
+        assert any(
+            "gce-notemplate-delivery-001" in r.message for r in caplog.records
+        ), "delivery_id not found in warning log for missing template"
+
+    @patch("app.clients.gcloud_client.compute_v1")
+    def test_create_runner_instance_error_logs_delivery_id(
+        self, mock_compute, mock_env_vars, caplog
+    ):
+        """Test that delivery_id is logged when instance creation fails."""
+        mock_instance_client = MagicMock()
+        mock_instance_client.insert.side_effect = Exception("API Error")
+        mock_compute.InstancesClient.return_value = mock_instance_client
+
+        mock_templates_client = MagicMock()
+        mock_template = MagicMock()
+        mock_template.name = "gcp-ubuntu-24-04-12345678901234"
+        mock_template.self_link = (
+            "https://www.googleapis.com/compute/v1/projects/test-project/regions/us-central1/"
+            "instanceTemplates/gcp-ubuntu-24-04-12345678901234"
+        )
+        mock_templates_client.list.return_value = [mock_template]
+        mock_compute.RegionInstanceTemplatesClient.return_value = mock_templates_client
+
+        client = GCloudClient()
+
+        with caplog.at_level(logging.ERROR, logger="app.clients.gcloud_client"):
+            with pytest.raises(Exception, match="API Error"):
+                client.create_runner_instance(
+                    "fake-token",
+                    "https://github.com/owner/repo",
+                    "gcp-ubuntu-24.04",
+                    delivery_id="gce-error-delivery-001",
+                )
+
+        assert any(
+            "gce-error-delivery-001" in r.message for r in caplog.records
+        ), "delivery_id not found in error log on instance creation failure"
+
+    @patch("app.clients.gcloud_client.compute_v1")
+    def test_delete_runner_instance_error_logs_delivery_id(
+        self, mock_compute, mock_env_vars, caplog
+    ):
+        """Test that delivery_id is logged when instance deletion fails."""
+        mock_instance_client = MagicMock()
+        mock_instance_client.delete.side_effect = Exception("Delete Error")
+        mock_compute.InstancesClient.return_value = mock_instance_client
+
+        client = GCloudClient()
+
+        with caplog.at_level(logging.ERROR, logger="app.clients.gcloud_client"):
+            with pytest.raises(Exception, match="Delete Error"):
+                client.delete_runner_instance(
+                    "runner-12345", delivery_id="gce-delerr-delivery-001"
+                )
+
+        assert any(
+            "gce-delerr-delivery-001" in r.message for r in caplog.records
+        ), "delivery_id not found in error log on instance deletion failure"

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -1,4 +1,5 @@
 import pytest
+import logging
 from unittest.mock import patch, MagicMock
 from app.clients.github_client import GitHubClient
 
@@ -152,3 +153,51 @@ class TestGitHubClient:
         client = GitHubClient()
         with pytest.raises(Exception, match="Key error"):
             client._generate_jwt()
+
+
+class TestGitHubClientDeliveryIdLogging:
+    """Tests to verify that delivery_id is logged in GitHubClient methods."""
+
+    @patch("app.clients.github_client.requests.post")
+    @patch.object(GitHubClient, "get_installation_access_token")
+    def test_registration_token_for_repo_logs_delivery_id(
+        self, mock_install_token, mock_post, mock_env_vars, caplog
+    ):
+        """Test that delivery_id is logged when getting a registration token for a repo."""
+        mock_install_token.return_value = "INSTALL_TOKEN"
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"token": "REG_TOKEN"}
+        mock_post.return_value = mock_response
+
+        client = GitHubClient()
+
+        with caplog.at_level(logging.INFO, logger="app.clients.github_client"):
+            client.get_registration_token(
+                repo_name="owner/repo", delivery_id="gh-repo-delivery-001"
+            )
+
+        assert any(
+            "gh-repo-delivery-001" in r.message for r in caplog.records
+        ), "delivery_id not found in log for repo registration token"
+
+    @patch("app.clients.github_client.requests.post")
+    @patch.object(GitHubClient, "get_installation_access_token")
+    def test_registration_token_for_org_logs_delivery_id(
+        self, mock_install_token, mock_post, mock_env_vars, caplog
+    ):
+        """Test that delivery_id is logged when getting a registration token for an org."""
+        mock_install_token.return_value = "INSTALL_TOKEN"
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"token": "ORG_TOKEN"}
+        mock_post.return_value = mock_response
+
+        client = GitHubClient()
+
+        with caplog.at_level(logging.INFO, logger="app.clients.github_client"):
+            client.get_registration_token(
+                org_name="my-org", delivery_id="gh-org-delivery-001"
+            )
+
+        assert any(
+            "gh-org-delivery-001" in r.message for r in caplog.records
+        ), "delivery_id not found in log for org registration token"

--- a/tests/unit/test_routes_webhook.py
+++ b/tests/unit/test_routes_webhook.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from unittest.mock import patch
 
 
@@ -18,7 +19,10 @@ class TestWebhookRoutes:
             '/webhook',
             data=json.dumps(sample_workflow_job_payload),
             content_type='application/json',
-            headers={'X-GitHub-Event': 'workflow_job'}
+            headers={
+                'X-GitHub-Event': 'workflow_job',
+                'X-GitHub-Delivery': 'abc-123-def'
+            }
         )
 
         assert response.status_code == 200
@@ -51,7 +55,10 @@ class TestWebhookRoutes:
             '/webhook',
             data=json.dumps(payload),
             content_type='application/json',
-            headers={'X-GitHub-Event': 'workflow_job'}
+            headers={
+                'X-GitHub-Event': 'workflow_job',
+                'X-GitHub-Delivery': 'delivery-created-001'
+            }
         )
 
         assert response.status_code == 200
@@ -79,7 +86,10 @@ class TestWebhookRoutes:
             '/webhook',
             data=json.dumps(payload),
             content_type='application/json',
-            headers={'X-GitHub-Event': 'workflow_job'}
+            headers={
+                'X-GitHub-Event': 'workflow_job',
+                'X-GitHub-Delivery': 'delivery-deleted-001'
+            }
         )
 
         assert response.status_code == 200
@@ -111,7 +121,10 @@ class TestWebhookRoutes:
             '/webhook',
             data=json.dumps(payload),
             content_type='application/json',
-            headers={'X-GitHub-Event': 'workflow_job'}
+            headers={
+                'X-GitHub-Event': 'workflow_job',
+                'X-GitHub-Delivery': 'delivery-ignored-001'
+            }
         )
 
         assert response.status_code == 200
@@ -128,7 +141,10 @@ class TestWebhookRoutes:
             '/webhook',
             data=json.dumps(sample_installation_payload),
             content_type='application/json',
-            headers={'X-GitHub-Event': 'installation'}
+            headers={
+                'X-GitHub-Event': 'installation',
+                'X-GitHub-Delivery': 'delivery-install-001'
+            }
         )
 
         assert response.status_code == 200
@@ -144,7 +160,10 @@ class TestWebhookRoutes:
             '/webhook',
             data=json.dumps(payload),
             content_type='application/json',
-            headers={'X-GitHub-Event': 'unknown_event'}
+            headers={
+                'X-GitHub-Event': 'unknown_event',
+                'X-GitHub-Delivery': 'delivery-unknown-001'
+            }
         )
 
         assert response.status_code == 200
@@ -162,7 +181,10 @@ class TestWebhookRoutes:
             '/webhook',
             data=json.dumps(sample_workflow_job_payload),
             content_type='application/json',
-            headers={'X-GitHub-Event': 'workflow_job'}
+            headers={
+                'X-GitHub-Event': 'workflow_job',
+                'X-GitHub-Delivery': 'delivery-error-001'
+            }
         )
 
         assert response.status_code == 500
@@ -181,7 +203,8 @@ class TestWebhookRoutes:
             content_type='application/json',
             headers={
                 'X-GitHub-Event': 'workflow_job',
-                'X-Hub-Signature-256': 'invalid'
+                'X-Hub-Signature-256': 'invalid',
+                'X-GitHub-Delivery': 'delivery-sig-001'
             }
         )
 
@@ -194,8 +217,168 @@ class TestWebhookRoutes:
             '/webhook',
             data=json.dumps({'zen': 'test'}),
             content_type='application/json',
-            headers={'X-GitHub-Event': 'ping'}
+            headers={
+                'X-GitHub-Event': 'ping',
+                'X-GitHub-Delivery': 'delivery-ping-001'
+            }
         )
 
         assert response.status_code == 200
         assert response.json['status'] == 'success'
+
+
+class TestWebhookDeliveryIdLogging:
+    """Tests to verify that X-GitHub-Delivery header is logged for correlation."""
+
+    @patch('app.routes.webhook.verify_github_signature')
+    @patch('app.routes.webhook.WebhookService')
+    def test_delivery_id_logged_on_workflow_job(
+        self, mock_webhook_service, mock_verify, client, caplog
+    ):
+        """Test that delivery_id is logged when processing a workflow_job event."""
+        mock_verify.return_value = True
+        mock_service_instance = mock_webhook_service.return_value
+        mock_service_instance.handle_workflow_job.return_value = {
+            "action": "created",
+            "runner_name": "runner-abc123"
+        }
+
+        payload = {
+            'action': 'queued',
+            'workflow_job': {'labels': ['gcp-ubuntu-24.04']},
+            'repository': {
+                'html_url': 'https://github.com/owner/repo',
+                'full_name': 'owner/repo'
+            }
+        }
+
+        with caplog.at_level(logging.INFO, logger='app.routes.webhook'):
+            client.post(
+                '/webhook',
+                data=json.dumps(payload),
+                content_type='application/json',
+                headers={
+                    'X-GitHub-Event': 'workflow_job',
+                    'X-GitHub-Delivery': 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
+                }
+            )
+
+        assert any(
+            'f47ac10b-58cc-4372-a567-0e02b2c3d479' in record.message
+            for record in caplog.records
+        ), "delivery_id was not found in log output"
+
+    @patch('app.routes.webhook.verify_github_signature')
+    def test_delivery_id_logged_on_unknown_event(self, mock_verify, client, caplog):
+        """Test that delivery_id is logged for unknown event types."""
+        mock_verify.return_value = True
+
+        with caplog.at_level(logging.WARNING, logger='app.routes.webhook'):
+            client.post(
+                '/webhook',
+                data=json.dumps({'action': 'test'}),
+                content_type='application/json',
+                headers={
+                    'X-GitHub-Event': 'unknown_event',
+                    'X-GitHub-Delivery': 'aaaabbbb-cccc-dddd-eeee-ffffffffffff'
+                }
+            )
+
+        assert any(
+            'aaaabbbb-cccc-dddd-eeee-ffffffffffff' in record.message
+            for record in caplog.records
+        ), "delivery_id was not found in log output for unknown event"
+
+    @patch('app.routes.webhook.verify_github_signature')
+    def test_delivery_id_logged_on_invalid_signature(self, mock_verify, client, caplog):
+        """Test that delivery_id is logged when signature verification fails."""
+        mock_verify.return_value = False
+
+        with caplog.at_level(logging.ERROR, logger='app.routes.webhook'):
+            client.post(
+                '/webhook',
+                data=json.dumps({'test': 'data'}),
+                content_type='application/json',
+                headers={
+                    'X-GitHub-Event': 'workflow_job',
+                    'X-Hub-Signature-256': 'invalid',
+                    'X-GitHub-Delivery': '11112222-3333-4444-5555-666677778888'
+                }
+            )
+
+        assert any(
+            '11112222-3333-4444-5555-666677778888' in record.message
+            for record in caplog.records
+        ), "delivery_id was not found in log output for invalid signature"
+
+    @patch('app.routes.webhook.verify_github_signature')
+    @patch('app.routes.webhook.WebhookService')
+    def test_delivery_id_logged_on_webhook_error(
+        self, mock_webhook_service, mock_verify, client, caplog
+    ):
+        """Test that delivery_id is logged when webhook processing fails."""
+        mock_verify.return_value = True
+        mock_service_instance = mock_webhook_service.return_value
+        mock_service_instance.handle_workflow_job.side_effect = Exception("boom")
+
+        payload = {
+            'action': 'queued',
+            'workflow_job': {'labels': ['gcp-ubuntu-24.04']},
+            'repository': {
+                'html_url': 'https://github.com/owner/repo',
+                'full_name': 'owner/repo'
+            }
+        }
+
+        with caplog.at_level(logging.ERROR, logger='app.routes.webhook'):
+            client.post(
+                '/webhook',
+                data=json.dumps(payload),
+                content_type='application/json',
+                headers={
+                    'X-GitHub-Event': 'workflow_job',
+                    'X-GitHub-Delivery': 'error-delivery-id-999'
+                }
+            )
+
+        assert any(
+            'error-delivery-id-999' in record.message
+            for record in caplog.records
+        ), "delivery_id was not found in error log output"
+
+    @patch('app.routes.webhook.verify_github_signature')
+    @patch('app.routes.webhook.WebhookService')
+    def test_delivery_id_none_when_header_missing(
+        self, mock_webhook_service, mock_verify, client, caplog
+    ):
+        """Test that delivery_id is logged as None when header is missing."""
+        mock_verify.return_value = True
+        mock_service_instance = mock_webhook_service.return_value
+        mock_service_instance.handle_workflow_job.return_value = {
+            "action": "created",
+            "runner_name": "runner-no-delivery"
+        }
+
+        payload = {
+            'action': 'queued',
+            'workflow_job': {'labels': ['gcp-ubuntu-24.04']},
+            'repository': {
+                'html_url': 'https://github.com/owner/repo',
+                'full_name': 'owner/repo'
+            }
+        }
+
+        with caplog.at_level(logging.INFO, logger='app.routes.webhook'):
+            response = client.post(
+                '/webhook',
+                data=json.dumps(payload),
+                content_type='application/json',
+                headers={'X-GitHub-Event': 'workflow_job'}
+            )
+
+        assert response.status_code == 200
+        # delivery_id should be None in the log since header was not sent
+        assert any(
+            'delivery_id: None' in record.message
+            for record in caplog.records
+        ), "delivery_id: None was not found in log output when header is missing"

--- a/tests/unit/test_routes_webhook.py
+++ b/tests/unit/test_routes_webhook.py
@@ -29,7 +29,9 @@ class TestWebhookRoutes:
         assert response.json['status'] == 'success'
         assert response.json['action'] == 'created'
         assert response.json['runner_name'] == 'runner-abc123'
-        mock_service_instance.handle_workflow_job.assert_called_once()
+        mock_service_instance.handle_workflow_job.assert_called_once_with(
+            sample_workflow_job_payload, delivery_id="abc-123-def"
+        )
 
     @patch('app.routes.webhook.verify_github_signature')
     @patch('app.routes.webhook.WebhookService')

--- a/tests/unit/test_routes_webhook.py
+++ b/tests/unit/test_routes_webhook.py
@@ -9,7 +9,10 @@ class TestWebhookRoutes:
         """Test handling workflow_job webhook."""
         mock_verify.return_value = True
         mock_service_instance = mock_webhook_service.return_value
-        mock_service_instance.handle_workflow_job.return_value = None
+        mock_service_instance.handle_workflow_job.return_value = {
+            "action": "created",
+            "runner_name": "runner-abc123"
+        }
 
         response = client.post(
             '/webhook',
@@ -20,7 +23,101 @@ class TestWebhookRoutes:
 
         assert response.status_code == 200
         assert response.json['status'] == 'success'
+        assert response.json['action'] == 'created'
+        assert response.json['runner_name'] == 'runner-abc123'
         mock_service_instance.handle_workflow_job.assert_called_once()
+
+    @patch('app.routes.webhook.verify_github_signature')
+    @patch('app.routes.webhook.WebhookService')
+    def test_workflow_job_webhook_created_response(self, mock_webhook_service, mock_verify, client):
+        """Test that created runner name is included in the response body."""
+        mock_verify.return_value = True
+        mock_service_instance = mock_webhook_service.return_value
+        mock_service_instance.handle_workflow_job.return_value = {
+            "action": "created",
+            "runner_name": "runner-uuid-12345"
+        }
+
+        payload = {
+            'action': 'queued',
+            'workflow_job': {'labels': ['gcp-ubuntu-24.04']},
+            'repository': {
+                'html_url': 'https://github.com/owner/repo',
+                'full_name': 'owner/repo'
+            }
+        }
+
+        response = client.post(
+            '/webhook',
+            data=json.dumps(payload),
+            content_type='application/json',
+            headers={'X-GitHub-Event': 'workflow_job'}
+        )
+
+        assert response.status_code == 200
+        assert response.json['status'] == 'success'
+        assert response.json['action'] == 'created'
+        assert response.json['runner_name'] == 'runner-uuid-12345'
+
+    @patch('app.routes.webhook.verify_github_signature')
+    @patch('app.routes.webhook.WebhookService')
+    def test_workflow_job_webhook_deleted_response(self, mock_webhook_service, mock_verify, client):
+        """Test that deleted runner name is included in the response body."""
+        mock_verify.return_value = True
+        mock_service_instance = mock_webhook_service.return_value
+        mock_service_instance.handle_workflow_job.return_value = {
+            "action": "deleted",
+            "runner_name": "runner-12345"
+        }
+
+        payload = {
+            'action': 'completed',
+            'workflow_job': {'runner_name': 'runner-12345'}
+        }
+
+        response = client.post(
+            '/webhook',
+            data=json.dumps(payload),
+            content_type='application/json',
+            headers={'X-GitHub-Event': 'workflow_job'}
+        )
+
+        assert response.status_code == 200
+        assert response.json['status'] == 'success'
+        assert response.json['action'] == 'deleted'
+        assert response.json['runner_name'] == 'runner-12345'
+
+    @patch('app.routes.webhook.verify_github_signature')
+    @patch('app.routes.webhook.WebhookService')
+    def test_workflow_job_webhook_ignored_response(self, mock_webhook_service, mock_verify, client):
+        """Test that ignored jobs return null runner_name in response body."""
+        mock_verify.return_value = True
+        mock_service_instance = mock_webhook_service.return_value
+        mock_service_instance.handle_workflow_job.return_value = {
+            "action": "ignored",
+            "runner_name": None
+        }
+
+        payload = {
+            'action': 'queued',
+            'workflow_job': {'labels': ['ubuntu-latest']},
+            'repository': {
+                'html_url': 'https://github.com/owner/repo',
+                'full_name': 'owner/repo'
+            }
+        }
+
+        response = client.post(
+            '/webhook',
+            data=json.dumps(payload),
+            content_type='application/json',
+            headers={'X-GitHub-Event': 'workflow_job'}
+        )
+
+        assert response.status_code == 200
+        assert response.json['status'] == 'success'
+        assert response.json['action'] == 'ignored'
+        assert response.json['runner_name'] is None
 
     @patch('app.routes.webhook.verify_github_signature')
     def test_installation_webhook(self, mock_verify, client, sample_installation_payload):

--- a/tests/unit/test_webhook_service.py
+++ b/tests/unit/test_webhook_service.py
@@ -1,4 +1,5 @@
 import pytest
+import logging
 from unittest.mock import Mock, patch
 from app.services.webhook_service import WebhookService
 
@@ -29,15 +30,18 @@ class TestWebhookService:
             }
         }
 
-        result = service.handle_workflow_job(payload)
+        result = service.handle_workflow_job(payload, delivery_id="delivery-001")
 
         assert result == {"action": "created", "runner_name": "runner-abc123"}
-        mock_gh_client.get_registration_token.assert_called_once_with(repo_name='owner/repo')
+        mock_gh_client.get_registration_token.assert_called_once_with(
+            repo_name='owner/repo', delivery_id="delivery-001"
+        )
         mock_gc_client.create_runner_instance.assert_called_once_with(
             'fake-token',
             'https://github.com/owner/repo',
             'gcp-ubuntu-24.04',
-            'owner/repo'
+            'owner/repo',
+            delivery_id="delivery-001",
         )
 
     @patch('app.services.webhook_service.GCloudClient')
@@ -68,10 +72,12 @@ class TestWebhookService:
             }
         }
 
-        result = service.handle_workflow_job(payload)
+        result = service.handle_workflow_job(payload, delivery_id="delivery-org-001")
 
         assert result == {"action": "created", "runner_name": "runner-org456"}
-        mock_gh_client.get_registration_token.assert_called_once_with(org_name='my-org')
+        mock_gh_client.get_registration_token.assert_called_once_with(
+            org_name='my-org', delivery_id="delivery-org-001"
+        )
 
     @patch('app.services.webhook_service.GCloudClient')
     @patch('app.services.webhook_service.GitHubClient')
@@ -96,7 +102,9 @@ class TestWebhookService:
             }
         }
 
-        result = service.handle_workflow_job(payload)
+        result = service.handle_workflow_job(
+            payload, delivery_id="delivery-nomatch-001"
+        )
 
         assert result == {"action": "ignored", "runner_name": None}
         mock_gh_client.get_registration_token.assert_not_called()
@@ -121,10 +129,14 @@ class TestWebhookService:
             }
         }
 
-        result = service.handle_workflow_job(payload)
+        result = service.handle_workflow_job(
+            payload, delivery_id="delivery-completed-001"
+        )
 
         assert result == {"action": "deleted", "runner_name": "runner-12345"}
-        mock_gc_client.delete_runner_instance.assert_called_once_with('runner-12345')
+        mock_gc_client.delete_runner_instance.assert_called_once_with(
+            'runner-12345', delivery_id="delivery-completed-001"
+        )
 
     @patch('app.services.webhook_service.GCloudClient')
     @patch('app.services.webhook_service.GitHubClient')
@@ -143,7 +155,9 @@ class TestWebhookService:
             'workflow_job': {}
         }
 
-        result = service.handle_workflow_job(payload)
+        result = service.handle_workflow_job(
+            payload, delivery_id="delivery-norunner-001"
+        )
 
         assert result == {"action": "deleted", "runner_name": None}
         mock_gc_client.delete_runner_instance.assert_not_called()
@@ -173,7 +187,7 @@ class TestWebhookService:
         }
 
         with pytest.raises(Exception, match="API Error"):
-            service.handle_workflow_job(payload)
+            service.handle_workflow_job(payload, delivery_id="delivery-error-001")
 
     @patch('app.services.webhook_service.GCloudClient')
     @patch('app.services.webhook_service.GitHubClient')
@@ -194,7 +208,7 @@ class TestWebhookService:
             }
         }
 
-        result = service.handle_workflow_job(payload)
+        result = service.handle_workflow_job(payload, delivery_id="delivery-norepo-001")
 
         assert result == {"action": "created", "runner_name": None}
         mock_gh_client.get_registration_token.assert_not_called()
@@ -221,7 +235,198 @@ class TestWebhookService:
         }
 
         # Should not raise exception, just log error and return runner_name
-        result = service.handle_workflow_job(payload)
+        result = service.handle_workflow_job(payload, delivery_id="delivery-delerr-001")
 
         assert result == {"action": "deleted", "runner_name": "runner-12345"}
-        mock_gc_client.delete_runner_instance.assert_called_once_with('runner-12345')
+        mock_gc_client.delete_runner_instance.assert_called_once_with(
+            'runner-12345', delivery_id="delivery-delerr-001"
+        )
+
+
+class TestWebhookServiceDeliveryIdLogging:
+    """Tests to verify that delivery_id is logged throughout the webhook service."""
+
+    @patch("app.services.webhook_service.GCloudClient")
+    @patch("app.services.webhook_service.GitHubClient")
+    def test_delivery_id_logged_on_queued_job(
+        self, mock_gh_client_class, mock_gc_client_class, caplog
+    ):
+        """Test that delivery_id appears in logs when processing a queued job."""
+        mock_gh_client = Mock()
+        mock_gh_client.get_registration_token.return_value = "fake-token"
+        mock_gh_client_class.return_value = mock_gh_client
+
+        mock_gc_client = Mock()
+        mock_gc_client.create_runner_instance.return_value = "runner-abc123"
+        mock_gc_client_class.return_value = mock_gc_client
+
+        service = WebhookService()
+
+        payload = {
+            "action": "queued",
+            "workflow_job": {"labels": ["gcp-ubuntu-24.04"]},
+            "repository": {
+                "html_url": "https://github.com/owner/repo",
+                "full_name": "owner/repo",
+            },
+        }
+
+        with caplog.at_level(logging.INFO, logger="app.services.webhook_service"):
+            service.handle_workflow_job(payload, delivery_id="queued-delivery-123")
+
+        delivery_logs = [
+            r for r in caplog.records if "queued-delivery-123" in r.message
+        ]
+        assert (
+            len(delivery_logs) >= 2
+        ), "Expected delivery_id in at least 2 log lines (processing + label match)"
+
+    @patch("app.services.webhook_service.GCloudClient")
+    @patch("app.services.webhook_service.GitHubClient")
+    def test_delivery_id_logged_on_completed_job(
+        self, mock_gh_client_class, mock_gc_client_class, caplog
+    ):
+        """Test that delivery_id appears in logs when processing a completed job."""
+        mock_gh_client = Mock()
+        mock_gh_client_class.return_value = mock_gh_client
+
+        mock_gc_client = Mock()
+        mock_gc_client_class.return_value = mock_gc_client
+
+        service = WebhookService()
+
+        payload = {
+            "action": "completed",
+            "workflow_job": {"runner_name": "runner-12345"},
+        }
+
+        with caplog.at_level(logging.INFO, logger="app.services.webhook_service"):
+            service.handle_workflow_job(payload, delivery_id="completed-delivery-456")
+
+        delivery_logs = [
+            r for r in caplog.records if "completed-delivery-456" in r.message
+        ]
+        assert (
+            len(delivery_logs) >= 2
+        ), "Expected delivery_id in at least 2 log lines (processing + cleanup)"
+
+    @patch("app.services.webhook_service.GCloudClient")
+    @patch("app.services.webhook_service.GitHubClient")
+    def test_delivery_id_logged_on_no_matching_label(
+        self, mock_gh_client_class, mock_gc_client_class, caplog
+    ):
+        """Test that delivery_id appears in warning log when no matching label."""
+        mock_gh_client_class.return_value = Mock()
+        mock_gc_client_class.return_value = Mock()
+
+        service = WebhookService()
+
+        payload = {
+            "action": "queued",
+            "workflow_job": {"labels": ["ubuntu-latest"]},
+            "repository": {
+                "html_url": "https://github.com/owner/repo",
+                "full_name": "owner/repo",
+            },
+        }
+
+        with caplog.at_level(logging.WARNING, logger="app.services.webhook_service"):
+            service.handle_workflow_job(payload, delivery_id="nomatch-delivery-789")
+
+        assert any(
+            "nomatch-delivery-789" in r.message for r in caplog.records
+        ), "delivery_id not found in warning log for non-matching labels"
+
+    @patch("app.services.webhook_service.GCloudClient")
+    @patch("app.services.webhook_service.GitHubClient")
+    def test_delivery_id_logged_on_spawn_error(
+        self, mock_gh_client_class, mock_gc_client_class, caplog
+    ):
+        """Test that delivery_id appears in error log when spawning fails."""
+        mock_gh_client = Mock()
+        mock_gh_client.get_registration_token.side_effect = Exception("API Error")
+        mock_gh_client_class.return_value = mock_gh_client
+
+        mock_gc_client_class.return_value = Mock()
+
+        service = WebhookService()
+
+        payload = {
+            "action": "queued",
+            "workflow_job": {"labels": ["gcp-ubuntu-24.04"]},
+            "repository": {
+                "html_url": "https://github.com/owner/repo",
+                "full_name": "owner/repo",
+            },
+        }
+
+        with caplog.at_level(logging.ERROR, logger="app.services.webhook_service"):
+            with pytest.raises(Exception, match="API Error"):
+                service.handle_workflow_job(payload, delivery_id="error-delivery-999")
+
+        assert any(
+            "error-delivery-999" in r.message for r in caplog.records
+        ), "delivery_id not found in error log on spawn failure"
+
+    @patch("app.services.webhook_service.GCloudClient")
+    @patch("app.services.webhook_service.GitHubClient")
+    def test_delivery_id_forwarded_to_gcloud_client(
+        self, mock_gh_client_class, mock_gc_client_class
+    ):
+        """Test that delivery_id is forwarded to gcloud client on create and delete."""
+        mock_gh_client = Mock()
+        mock_gh_client.get_registration_token.return_value = "fake-token"
+        mock_gh_client_class.return_value = mock_gh_client
+
+        mock_gc_client = Mock()
+        mock_gc_client.create_runner_instance.return_value = "runner-fwd-123"
+        mock_gc_client_class.return_value = mock_gc_client
+
+        service = WebhookService()
+
+        # Test create path
+        payload = {
+            "action": "queued",
+            "workflow_job": {"labels": ["gcp-ubuntu-24.04"]},
+            "repository": {
+                "html_url": "https://github.com/owner/repo",
+                "full_name": "owner/repo",
+            },
+        }
+        service.handle_workflow_job(payload, delivery_id="fwd-create-001")
+        mock_gc_client.create_runner_instance.assert_called_once_with(
+            "fake-token",
+            "https://github.com/owner/repo",
+            "gcp-ubuntu-24.04",
+            "owner/repo",
+            delivery_id="fwd-create-001",
+        )
+
+    @patch("app.services.webhook_service.GCloudClient")
+    @patch("app.services.webhook_service.GitHubClient")
+    def test_delivery_id_forwarded_to_github_client(
+        self, mock_gh_client_class, mock_gc_client_class
+    ):
+        """Test that delivery_id is forwarded to github client on token request."""
+        mock_gh_client = Mock()
+        mock_gh_client.get_registration_token.return_value = "fake-token"
+        mock_gh_client_class.return_value = mock_gh_client
+
+        mock_gc_client = Mock()
+        mock_gc_client.create_runner_instance.return_value = "runner-fwd-456"
+        mock_gc_client_class.return_value = mock_gc_client
+
+        service = WebhookService()
+
+        payload = {
+            "action": "queued",
+            "workflow_job": {"labels": ["gcp-ubuntu-24.04"]},
+            "repository": {
+                "html_url": "https://github.com/owner/repo",
+                "full_name": "owner/repo",
+            },
+        }
+        service.handle_workflow_job(payload, delivery_id="fwd-gh-001")
+        mock_gh_client.get_registration_token.assert_called_once_with(
+            repo_name="owner/repo", delivery_id="fwd-gh-001"
+        )

--- a/tests/unit/test_webhook_service.py
+++ b/tests/unit/test_webhook_service.py
@@ -13,6 +13,7 @@ class TestWebhookService:
         mock_gh_client_class.return_value = mock_gh_client
 
         mock_gc_client = Mock()
+        mock_gc_client.create_runner_instance.return_value = "runner-abc123"
         mock_gc_client_class.return_value = mock_gc_client
 
         service = WebhookService()
@@ -28,8 +29,9 @@ class TestWebhookService:
             }
         }
 
-        service.handle_workflow_job(payload)
+        result = service.handle_workflow_job(payload)
 
+        assert result == {"action": "created", "runner_name": "runner-abc123"}
         mock_gh_client.get_registration_token.assert_called_once_with(repo_name='owner/repo')
         mock_gc_client.create_runner_instance.assert_called_once_with(
             'fake-token',
@@ -47,6 +49,7 @@ class TestWebhookService:
         mock_gh_client_class.return_value = mock_gh_client
 
         mock_gc_client = Mock()
+        mock_gc_client.create_runner_instance.return_value = "runner-org456"
         mock_gc_client_class.return_value = mock_gc_client
 
         service = WebhookService()
@@ -65,8 +68,9 @@ class TestWebhookService:
             }
         }
 
-        service.handle_workflow_job(payload)
+        result = service.handle_workflow_job(payload)
 
+        assert result == {"action": "created", "runner_name": "runner-org456"}
         mock_gh_client.get_registration_token.assert_called_once_with(org_name='my-org')
 
     @patch('app.services.webhook_service.GCloudClient')
@@ -92,8 +96,9 @@ class TestWebhookService:
             }
         }
 
-        service.handle_workflow_job(payload)
+        result = service.handle_workflow_job(payload)
 
+        assert result == {"action": "ignored", "runner_name": None}
         mock_gh_client.get_registration_token.assert_not_called()
         mock_gc_client.create_runner_instance.assert_not_called()
 
@@ -116,8 +121,9 @@ class TestWebhookService:
             }
         }
 
-        service.handle_workflow_job(payload)
+        result = service.handle_workflow_job(payload)
 
+        assert result == {"action": "deleted", "runner_name": "runner-12345"}
         mock_gc_client.delete_runner_instance.assert_called_once_with('runner-12345')
 
     @patch('app.services.webhook_service.GCloudClient')
@@ -137,8 +143,9 @@ class TestWebhookService:
             'workflow_job': {}
         }
 
-        service.handle_workflow_job(payload)
+        result = service.handle_workflow_job(payload)
 
+        assert result == {"action": "deleted", "runner_name": None}
         mock_gc_client.delete_runner_instance.assert_not_called()
 
     @patch('app.services.webhook_service.GCloudClient')
@@ -187,8 +194,9 @@ class TestWebhookService:
             }
         }
 
-        service.handle_workflow_job(payload)
+        result = service.handle_workflow_job(payload)
 
+        assert result == {"action": "created", "runner_name": None}
         mock_gh_client.get_registration_token.assert_not_called()
         mock_gc_client.create_runner_instance.assert_not_called()
 
@@ -212,7 +220,8 @@ class TestWebhookService:
             }
         }
 
-        # Should not raise exception, just log error
-        service.handle_workflow_job(payload)
+        # Should not raise exception, just log error and return runner_name
+        result = service.handle_workflow_job(payload)
 
+        assert result == {"action": "deleted", "runner_name": "runner-12345"}
         mock_gc_client.delete_runner_instance.assert_called_once_with('runner-12345')


### PR DESCRIPTION
First off, thanks for taking the time to contribute!

## Please Complete the Following

- [x] I read [CONTRIBUTING.md](https://github.com/Cyclenerd/google-cloud-github-runner/blob/master/CONTRIBUTING.md)

## Notes

This will return the affected Runner Name in Webhook Operations and add the X-GitHub-Delivery Header to Logs to build a correlation between GitHub Webhook Requests and the Operations on Compute Engine.

We had some concurrency issues a little while ago and I needed to get additional Details from the Point that I wasn't able to identity which operations have been caused by which Webhook Delivery and which Webhooks haven't been delivered for which reason.

-- 

Example Response Payload (we use full length uuid v7 for runner names):

```json
{"action":"deleted","runner_name":"runner-019d3e12-1434-75f8-8caa-6284eb790d05","status":"success"}
```

Which was logged in Cloud Run as the following:

```
2026-03-30 09:31:20,355 - app.routes.webhook - INFO - Received webhook event: workflow_job, delivery_id: 353f3530-2c1b-11f1-9b22-5695ca7b1ecb
[... additional log lines ...]
2026-03-30 09:31:20,704 - app.routes.webhook - INFO - Webhook processed successfully, action: deleted, runner_name: runner-019d3e12-1434-75f8-8caa-6284eb790d05, delivery_id: 353f3530-2c1b-11f1-9b22-5695ca7b1ecb
```